### PR TITLE
added bandai 16 mappers family

### DIFF
--- a/FamicomDumper/mappers/153.cs
+++ b/FamicomDumper/mappers/153.cs
@@ -1,0 +1,34 @@
+﻿// The only game "Famicom Jump II - Saikyou no 7 Nin (Japan)" uses this mapper
+
+class BANDAI_LZ93D50_WRAM_CHRRAM_PRGROM : IMapper
+{
+    public string Name { get => "153 BANDAI SRAM"; }
+    public int Number { get => 153; }
+    public int DefaultPrgSize { get => 512 * 1024; }
+    public int DefaultChrSize { get => 0; }
+
+    public void DumpPrg(IFamicomDumperConnection dumper, List<byte> data, int size)
+    {
+        var banks = size / 0x4000;
+
+        for (var bank = 0; bank < banks; bank++)
+        {
+            Console.Write($"Reading PRG bank #{bank}/{banks}... ");
+
+            var outerBank = (byte)((bank & 0x10) >> 4);
+            dumper.WriteCpu(0x8000, outerBank);
+            dumper.WriteCpu(0x8001, outerBank);
+            dumper.WriteCpu(0x8002, outerBank);
+            dumper.WriteCpu(0x8003, outerBank);
+
+            dumper.WriteCpu(0x8008, (byte)(bank & 0xF));
+            data.AddRange(dumper.ReadCpu(0x8000, 0x4000));
+            Console.WriteLine("OK");
+        }
+    }
+
+    public MirroringType GetMirroring(IFamicomDumperConnection dumper)
+    {
+        return MirroringType.MapperControlled;
+    }
+}

--- a/FamicomDumper/mappers/157.cs
+++ b/FamicomDumper/mappers/157.cs
@@ -1,0 +1,27 @@
+﻿// Bandai DATACH Joint ROM System
+
+class BANDAI_LZ93D50_BARCODE : IMapper
+{
+    public string Name { get => "BANDAI BARCODE"; }
+    public int Number { get => 157; }
+    public int DefaultPrgSize { get => 256 * 1024; }
+    public int DefaultChrSize { get => 0; }
+
+    public void DumpPrg(IFamicomDumperConnection dumper, List<byte> data, int size)
+    {
+        var banks = size / 0x4000;
+
+        for (var bank = 0; bank < banks; bank++)
+        {
+            Console.Write($"Reading PRG bank #{bank}/{banks}... ");
+            dumper.WriteCpu(0x8008, (byte)(bank & 0xFF));
+            data.AddRange(dumper.ReadCpu(0x8000, 0x4000));
+            Console.WriteLine("OK");
+        }
+    }
+
+    public MirroringType GetMirroring(IFamicomDumperConnection dumper)
+    {
+        return MirroringType.MapperControlled;
+    }
+}

--- a/FamicomDumper/mappers/16.cs
+++ b/FamicomDumper/mappers/16.cs
@@ -1,0 +1,39 @@
+﻿class BANDAI_LZ93D50_CHRROM_PRGROM : IMapper
+{
+    public string Name { get => "BANDAI 16"; }
+    public int Number { get => 16; }
+    public int Submapper { get => 5; }
+    public int DefaultPrgSize { get => 256 * 1024; }
+    public int DefaultChrSize { get => 256 * 1024; }
+
+    public void DumpPrg(IFamicomDumperConnection dumper, List<byte> data, int size)
+    {
+        var banks = size / 0x4000;
+
+        for (var bank = 0; bank < banks; bank++)
+        {
+            Console.Write($"Reading PRG bank #{bank}/{banks}... ");
+            dumper.WriteCpu(0x8008, (byte)(bank & 0xF));
+            data.AddRange(dumper.ReadCpu(0x8000, 0x4000));
+            Console.WriteLine("OK");
+        }
+    }
+
+    public void DumpChr(IFamicomDumperConnection dumper, List<byte> data, int size)
+    {
+        var banks = size / 0x400;
+
+        for (var bank = 0; bank < banks; bank++)
+        {
+            Console.Write($"Reading CHR bank #{bank}/{banks}... ");
+            dumper.WriteCpu(0x8000, (byte)bank);
+            data.AddRange(dumper.ReadPpu(0x0000, 0x0400));
+            Console.WriteLine("OK");
+        }
+    }
+
+    public MirroringType GetMirroring(IFamicomDumperConnection dumper)
+    {
+        return MirroringType.MapperControlled;
+    }
+}


### PR DESCRIPTION
[INES Mapper 016](https://www.nesdev.org/wiki/INES_Mapper_016) general bandai mapper

[INES Mapper 153](https://www.nesdev.org/wiki/INES_Mapper_153) replaces the serial EEPROM with 8 KiB of battery-backed WRAM, and uses CHR-RAM instead of CHR-ROM. The only game uses this mapper is "Famicom Jump II - Saikyou no 7 Nin"

[INES Mapper 157](https://www.nesdev.org/wiki/INES_Mapper_157) adds a barcode reader, support for a second EEPROM, and uses CHR-RAM instead of CHR-ROM. DATACH Joint ROM System.

Tested on original carts: "Famicom Jump II - Saikyou no 7 Nin" and DATACH "Dragon Ball Z: Gekitou Tenkaichi Budoukai"